### PR TITLE
Add sklearn to required packages.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ setup(name=pkg_name,
         'pandas>=0.24.2',
         'numpy>=1.14.5',
         'matplotlib>=3.0.3',
-        'lifelines>=0.14.6'
+        'lifelines>=0.14.6',
+        'scikit-learn'
     ],
     include_package_data=True,
 )


### PR DESCRIPTION
tfdeepsurv needs sklearn in tfdeepsurv.datasets, but it's not listed in setup.py as a required package.